### PR TITLE
Add concurrent upload of staging buffers

### DIFF
--- a/src/vk/device.rs
+++ b/src/vk/device.rs
@@ -204,6 +204,11 @@ impl CommandBuffer {
     pub fn handle(&self) -> VkCommandBuffer {
         self.handle
     }
+
+    #[inline]
+    pub(crate) fn fence(&self) -> VkFence {
+        self.fence
+    }
 }
 
 impl Drop for CommandBuffer {

--- a/src/vk/mod.rs
+++ b/src/vk/mod.rs
@@ -20,6 +20,7 @@ mod device_queues;
 mod memory;
 mod geometry;
 mod model;
+mod queue_submit;
 
 mod staging;
 mod image;
@@ -38,6 +39,7 @@ pub use device_queues::*;
 pub use memory::*;
 pub use geometry::*;
 pub use model::*;
+pub use queue_submit::*;
 
 pub use staging::*;
 pub use crate::vk::image::*;

--- a/src/vk/queue_submit.rs
+++ b/src/vk/queue_submit.rs
@@ -1,0 +1,84 @@
+
+use std::sync::{Arc, Mutex};
+
+use crate::ffi::vk::*;
+
+use super::error::Result;
+use super::{Queue, CommandBuffer};
+
+pub struct QueueSubmit {
+    queue: Arc<Queue>,
+    state: Mutex<QueueSubmitState>,
+}
+
+impl QueueSubmit {
+    pub fn new(queue: &Arc<Queue>) -> Arc<Self> {
+        let this = Self {
+            queue: Arc::clone(queue),
+            state: Mutex::new(QueueSubmitState::new())
+        };
+        Arc::new(this)
+    }
+
+    pub fn defer_submit(&self, command_buffer: &Arc<CommandBuffer>, wait_mask: VkPipelineStageFlags) {
+        let command_buffer = Arc::clone(command_buffer);
+        let task = QueueSubmitTask::new(command_buffer, wait_mask);
+        let mut state = self.state.lock().unwrap();
+        state.tasks.push(task);
+    }
+
+    pub fn execute(&self) -> Result<()> {
+        unsafe {
+            let device = self.queue.device();
+            let state = self.state.lock().unwrap();
+            let fences: Vec<VkFence> = state.tasks.iter()
+                .map(|v| v.fence())
+                .collect();
+            vkResetFences(device.handle(), fences.len() as u32, fences.as_ptr())
+                .into_result()?;
+            for task in state.tasks.iter() {
+                task.submit(&self.queue);
+            }
+            vkWaitForFences(device.handle(), fences.len() as u32, fences.as_ptr(), VK_TRUE, crate::vk::DEFAULT_TIMEOUT)
+                .into_result()?;
+        }
+        Ok(())
+    }
+}
+
+struct QueueSubmitState {
+    tasks: Vec<QueueSubmitTask>,
+}
+
+impl QueueSubmitState {
+    fn new() -> Self {
+        Self {
+            tasks: vec![],
+        }
+    }
+}
+
+struct QueueSubmitTask {
+    command_buffer: Arc<CommandBuffer>,
+    wait_mask: VkPipelineStageFlags,
+}
+
+impl QueueSubmitTask {
+    fn new(command_buffer: Arc<CommandBuffer>, wait_mask: VkPipelineStageFlags) -> Self {
+        Self { command_buffer, wait_mask }
+    }
+
+    unsafe fn submit(&self, queue: &Arc<Queue>) {
+        let command_buffer_handle = self.command_buffer.handle();
+        let fence = self.command_buffer.fence();
+        let submit_info = VkSubmitInfo::with_command_buffer_wait(
+            1,
+            &command_buffer_handle,
+            &self.wait_mask);
+        vkQueueSubmit(queue.handle(), 1, &submit_info, fence);
+    }
+
+    fn fence(&self) -> VkFence {
+        self.command_buffer.fence()
+    }
+}


### PR DESCRIPTION
Adds a feature to concurrently submit commands. With that feature, we can optimize the first-time scene load time.

```
let queue_submit = QueueSubmit::new(queue);

queue_submit.defer_submit(command_buffer0, wait_mask);
queue_submit.defer_submit(command_buffer1, wait_mask);

queue_submit.execute();
```